### PR TITLE
Fix GitHub Pages main script path

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,10 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <!-- Use a relative path for the entry script so that GitHub Pages
+         can resolve the file correctly when the site is served from a
+         subdirectory. The build process will replace this path with the
+         optimized bundle. -->
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,12 @@
-import { useState } from 'react'
 import './App.css'
-import Home from './routes/Home';
-import Footer from './components/Footer';
+import Home from './routes/Home'
+import Footer from './components/Footer'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
     <>
-        <Home />
-        <Footer />
+      <Home />
+      <Footer />
     </>
   )
 }


### PR DESCRIPTION
## Summary
- load entry script via relative path so GitHub Pages resolves correctly
- remove unused state from App to satisfy lint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8dc9949988322a34acc6ca2129b29